### PR TITLE
more bashisms support multiple go modules

### DIFF
--- a/goprecommit
+++ b/goprecommit
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-[[ -z $GO ]] && GO="go"
+[[ -z "$GO" ]] && GO="go"
 
-if [[ ${GO##*/} == $GO ]]; then
+if [[ "${GO##*/}" == "$GO" ]]; then
 	GOBIN="$( type -p "$GO" 2> /dev/null )"
 
 	ret=$?
@@ -14,15 +14,15 @@ if [[ ${GO##*/} == $GO ]]; then
 	GO="$GOBIN"
 fi
 
-if ! [[ -x $GO ]]; then
+if ! [[ -x "$GO" ]]; then
 	echo "goprecommit: $GO is not an executable file." 2>&1
 	exit 1
 fi
 
 # Check for preqrequisites.
 for prereq in "git"; do
-	if ! type -p "${prereq}" > /dev/null 2>&1; then
-		echo "goprecommit: ${prereq} must be installed and in the path." 2>&1
+	if ! type -p "$prereq" > /dev/null 2>&1; then
+		echo "goprecommit: $prereq must be installed and in the path." 2>&1
 		exit 1
 	fi
 done
@@ -40,13 +40,13 @@ SHORT="false"
 QUIET="false"
 
 LINT="true"
-[[ $GOPRECOMMIT_NOLINT = "true" ]] && LINT="false"
+[[ "$GOPRECOMMIT_NOLINT" = "true" ]] && LINT="false"
 
 while [[ $# -gt 0 ]]; do
 	key="$1"
 	val="${key#*=}"
 
-	case $key in
+	case "$key" in
 	--cache)
 		NOCACHE=""
 	;;
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]]; do
 		NOCACHE="-count=1"
 	;;
 	--cache=*)
-		case $val in
+		case "$val" in
 		true)
 			NOCACHE=""
 		;;
@@ -75,7 +75,7 @@ while [[ $# -gt 0 ]]; do
 		LINT="false"
 	;;
 	--lint=*)
-		case $val in
+		case "$val" in
 		true|false)
 			LINT="$val"
 		;;
@@ -117,18 +117,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 function printf_verbose { true ; }
-if [[ $VERBOSE == "true" ]]; then
+if [[ "$VERBOSE" == "true" ]]; then
 	function printf_verbose { printf "$@" ; }
 fi
 
 function printf_not_short { printf "$@" ; }
-if [[ $SHORT == "true" ]]; then
+if [[ "$SHORT" == "true" ]]; then
 	function printf_not_short { true ; }
 fi
 
-
 function printf_not_quiet { printf "$@" ; }
-if [[ $QUIET == "true" ]]; then
+if [[ "$QUIET" == "true" ]]; then
 	function printf_not_quiet { true ; }
 fi
 
@@ -146,9 +145,8 @@ function gopath_bin_in_path {
 	while read -r path; do
 		if [[ "$path" == "${GOPATH}/bin" ]]; then
 			return 0
-			break
 		fi
-	done < <( echo $PATH | tr ':' '\n' )
+	done < <( echo "$PATH" | tr ':' '\n' )
 
 	return 1
 }
@@ -159,39 +157,39 @@ gopath_bin_in_path || PATH="${PATH}:${GOPATH}/bin"
 VERSION="$( "$GO" version | awk '//{ print $3 }' )"
 VERSION="${VERSION#go}"
 
-printf_verbose "found go version %s\n" "${VERSION}"
+printf_verbose "found go version %s\n" "$VERSION"
 
 function go_install {
 	local bin="$1"
 	local pkg="$2"
 
-	if type -p $bin > /dev/null 2>&1; then
+	if type -p "$bin" > /dev/null 2>&1; then
 		return 0
 	fi
 
-	case "${VERSION}" in
+	case "$VERSION" in
 	1.[0123456789]|1.[0123456789].*|1.[0123456789][a-z]*)
-		"$GO" get -u $pkg
+		"$GO" get -u "$pkg"
 	;;
 	1.1[012345]|1.1[012345].*|1.1[012345][a-z]*)
-		"$GO" get -u $pkg
+		"$GO" get -u "$pkg"
 	;;
 	*)
-		"$GO" install $pkg@latest
+		"$GO" install "${pkg}@latest"
 	;;
 	esac
 
-	if ! type -p $bin > /dev/null 2>&1; then
+	if ! type -p "$bin" > /dev/null 2>&1; then
 		echo "goprecommit: could not locate $bin even after installing $pkg" 2>&1
 		return 1
 	fi
 }
 
-go_install golint golang.org/x/lint/golint
-go_install goimports golang.org/x/tools/cmd/goimports
+go_install golint golang.org/x/lint/golint || exit 1
+go_install goimports golang.org/x/tools/cmd/goimports || exit 1
 
 readarray -t GOMODS < <( git ls-files | grep "\(^\|/\)go\.mod$" | grep -v "\(^\|/\)vendor/" )
-printf_verbose "found go.mods=%d\n" ${#GOMODS[@]}
+printf_verbose "found go.mods=%d\n" "${#GOMODS[@]}"
 
 if [[ ${#GOMODS[@]} -lt 1 ]]; then
 	log_warning "goprecommit" "Could not find any go.mod files."
@@ -200,13 +198,13 @@ fi
 
 function precommit_module {
 	local gomod="$1"
-	printf_verbose "using go.mod=%s\n" $gomod
+	printf_verbose "using go.mod=%s\n" "$gomod"
 
-	cd "$(dirname $gomod)"
+	cd "$(dirname "$gomod")" || return 1
 
 	local GO_MODULES="false"
 
-	case "${VERSION}" in
+	case "$VERSION" in
 	1.[0123456789]|1.[0123456789].*|1.[0123456789][a-z]*)
 	;;
 	1.10|1.10.*|1.10[a-z]*)
@@ -221,10 +219,10 @@ function precommit_module {
 	;;
 	esac
 
-	local MOD_PATH="${PWD#$GOPATH/src/}"
+	local MOD_PATH="${PWD#"$GOPATH"/src/}"
 	printf_verbose "found MOD_PATH=%s\n" "$MOD_PATH"
 
-	if [[ $MOD_PATH != $PWD || ! -r go.mod ]]; then
+	if [[ "$MOD_PATH" != "$PWD" || ! -r go.mod ]]; then
 		printf_verbose "ignoring go modules…\n"
 		unset GO_MODULES
 		unset GO_MOD_TIDY
@@ -261,19 +259,18 @@ function precommit_module {
 		dir="${dir#./}"
 
 		if [[ -d "${dir}/.git" ]]; then
-			printf_verbose "found subrepo: $dir\n"
+			printf_verbose "found subrepo: %s\n" "$dir"
 			SUBREPO["$dir"]="true"
 		fi
-
 	done < <( find . -type d -not \( -name ".?*" -prune -o -name "vendor" -prune \) )
 
 	if [[ "$GO_MODULES" == "true" ]]; then
 		printf_verbose "go mod ${GO_MOD_TIDY}…\n"
 		
 		while read -r line; do
-			line="$( echo "$line" | sed 's;^go: ;;' )"
+			line="${line#go: }"
 			log_hide "go mod ${GO_MOD_TIDY}" "$line"
-		done < <( "$GO" mod ${GO_MOD_TIDY} 2>&1 )
+		done < <( "$GO" mod "${GO_MOD_TIDY}" 2>&1 )
 	fi
 
 	printf_verbose "listing packages…\n"
@@ -305,7 +302,7 @@ function precommit_module {
 		while read -r line; do
 			log_error "gofmt" "$line"
 			((ISSUES++))
-		done < <(gofmt -l "${GOFILES[@]}")
+		done < <(gofmt -l "${GOFILES[@]}" 2>&1 )
 
 		printf_verbose "goimports on files…\n"
 
@@ -315,14 +312,12 @@ function precommit_module {
 		done < <( goimports -l "${GOFILES[@]}" 2>&1 )
 	fi
 
-	if [[ "$LINT" != "false" ]]; then
+	if [[ "$LINT" == "true" ]]; then
 		printf_verbose "golint on packages…\n"
 
 		# golint complains if we reference all of the files together, so we need to do a per-package check.
 		# We want to highlight any package that has golint errors, so we do each package separately.
 		for pkg in "${GOPKGS[@]}"; do
-			FLAG="false"
-
 			pkg="${pkg#$MOD_BASE}"
 
 			[[ "$pkg" == "/" ]] && pkg="."
@@ -330,6 +325,7 @@ function precommit_module {
 
 			printf_verbose "$ golint $pkg\n"
 
+			FLAG="false"
 			while read -r line; do
 				if [[ "$FLAG" != "true" ]]; then
 					log_error "golint" "$pkg"
@@ -338,7 +334,7 @@ function precommit_module {
 					((ISSUES++))
 				fi
 
-				line=${line#${PWD}/}
+				line="${line#${PWD}/}"
 				log_warning "golint" "$line"
 			done < <( golint "$pkg" 2>&1 )
 		done
@@ -353,7 +349,7 @@ function precommit_module {
 		line="$( echo "$line" | sed -e "s;\b\(_$PWD\|$MOD_PATH\)/;;g" -e "s;\b\(_$PWD\|$MOD_PATH\);.;g" )"
 
 		# Strip leading whitespace for easier matching.
-		case "$( echo "$line" | sed -e 's/^[ \t]*//g' )" in 
+		case "$( echo "$line" | sed -e 's/^[ \t]*//' )" in
 		"go: "*)
 			# go messages should be shadowed.
 			log_hide "go test" "$line"
@@ -368,23 +364,24 @@ function precommit_module {
 		PASS*)
 			log_ok "go test" "$line"
 		;;
-		FAIL) ;;
+		FAIL) ;; # Ignore lines that just say "FAIL".
 		---\ FAIL*)
 			# Failures should be highlighted as errors.
 			log_error "go test" "$line"
 			((ISSUES++))
 		;;
 		panic:*\[recovered\])
-			# recovered panics should be shadowed.
+			# recovered panics should be highlighted as warnings.
 			log_warning "go test" "$line"
+			((ISSUES++))
 		;;
 		FAIL*|panic:*)
-			# Failures should be highlighted as errors.
+			# Failures and panics should be highlighted as errors.
 			log_error "go test" "$line"
 			((ISSUES++))
 		;;
 		*cannot\ find\ package*)
-			# Failures should be highlighted as errors.
+			# Not being able to find a package should be highlighted as an error.
 			log_error "go test" "$line"
 			((ISSUES++))
 		;;
@@ -392,12 +389,13 @@ function precommit_module {
 			pkg="$( echo "$line" | awk '//{ print $2 }' )"
 
 			# If pkg has a leading underscore, then replace "_${PWD}/" with "./".
-			if [[ "${pkg#_}" != "${pkg}" ]]; then
+			if [[ "${pkg#_}" != "$pkg" ]]; then
 				pkg=".${pkg#_${PWD}}"
 			fi
 
-			pkgname="$( "$GO" list -f "{{.Name}}" $pkg 2>&1 )"
-			case $pkgname in
+			pkgname="$( "$GO" list -f "{{.Name}}" "$pkg" 2>&1 )"
+
+			case "$pkgname" in
 			main)
 				# If a main package does not have tests, then it should be shadowed.
 				log_hide "go test" "$line"
@@ -409,35 +407,38 @@ function precommit_module {
 			esac
 		;;
 		*)
-			line="$( echo "$line" | sed -e "s;${PWD};.;" )"
 			# Lines that we cannot recognize as anything else should be highlighted as warnings.
+			line="${line//"${PWD}"/.}"
 			log_warning "go test" "$line"
 			((ISSUES++)) # should additionally break commit attempt.
 		;;
 		esac
 	done < <( "$GO" test $NOCACHE "${TESTPKGS[@]}" 2>&1 )
 
-	return $ISSUES
+	# return $ISSUES would pass it through a uint8,
+	# so at exactly $ISSUES=256, we would accidentally return 0 instead.
+	[[ $ISSUES -ne 0 ]] && return 1
+	return 0
 }
 
 BLOCK_COMMIT="false"
 
 for gomod in "${GOMODS[@]}"; do
 	# run precommit_module in a subshell, since it can change directories.
-	if !( precommit_module $gomod ); then
+	if ! ( precommit_module "$gomod" ); then
 		BLOCK_COMMIT="true"
 	fi
 done
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
-case $branch in
+case "$branch" in
 master|main)
 	log_error "branch name" "Do not commit to ${branch}."
 	BLOCK_COMMIT="true"
 ;;
 esac
 
-find * -type f -name "*.*" -exec check-noeol \{\} \+ || BLOCK_COMMIT="true"
+find ./* -type f -name "*.*" -exec check-noeol \{\} \+ || BLOCK_COMMIT="true"
 
 [[ "$BLOCK_COMMIT" == "true" ]] && exit 1
 exit 0

--- a/goprecommit
+++ b/goprecommit
@@ -283,7 +283,7 @@ function precommit_module {
 		pkg="$( echo "$pkg" | sed -e "s;\b\(_$PWD\|$MOD_PATH\)/;;g" -e "s;\b\(_$PWD\|$MOD_PATH\);.;g" )"
 
 		if git check-ignore -q "$pkg"; then
-			# If the project would be ignored in git, then we want to process it.
+			# If the project would be ignored in git, then we don't want to process it.
 			printf_verbose "package is ignored in git: %s\n" "$pkg"
 			continue
 		fi
@@ -423,6 +423,7 @@ function precommit_module {
 BLOCK_COMMIT="false"
 
 for gomod in "${GOMODS[@]}"; do
+	# run precommit_module in a subshell, since it can change directories.
 	if !( precommit_module $gomod ); then
 		BLOCK_COMMIT="true"
 	fi
@@ -436,7 +437,7 @@ master|main)
 ;;
 esac
 
-# find * -type f -name "*.*" -exec check-noeol \{\} \+ || BLOCK_COMMIT="true"
+find * -type f -name "*.*" -exec check-noeol \{\} \+ || BLOCK_COMMIT="true"
 
 [[ "$BLOCK_COMMIT" == "true" ]] && exit 1
 exit 0

--- a/goprecommit
+++ b/goprecommit
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 
-# We use $NOTICE, $WARNING, $ERROR and $NORMAL here to color things.
-HIDE="\e[0;30;1m" # BOLD blue on black
-GOOD="\e[0;92;1m" # BOLD green on black
-INFO="\e[0;94;1m" # BOLD blue on black
-NOTICE="\e[0;96;1m" # BOLD cyan on black
-WARNING="\e[0;93;1m" # BOLD yellow on black
-ERROR="\e[0;91;1m" # BOLD red on black
-NORMAL="\e[m" # reset NORMAL colors
-CLEAR="\e[J" # CLEAR TO END-OF-LINE
-STARTCLEAR="\r$CLEAR"
+[[ -z $GO ]] && GO="go"
 
-[[ -z "$GO" ]] && GO="go"
-
-if [[ "${GO#/}" == "$GO" ]]; then
-	GOBIN="$( which ${GO} 2> /dev/null )"
+if [[ ${GO##*/} == $GO ]]; then
+	GOBIN="$( type -p "$GO" 2> /dev/null )"
 
 	ret=$?
 	if [[ $ret -gt 0 ]]; then
@@ -25,14 +14,14 @@ if [[ "${GO#/}" == "$GO" ]]; then
 	GO="$GOBIN"
 fi
 
-if ! [[ -f "$GO" && -x "$GO" ]]; then
-	echo "goprecommit: ${GO} is not an executable file." 2>&1
+if ! [[ -x $GO ]]; then
+	echo "goprecommit: $GO is not an executable file." 2>&1
 	exit 1
 fi
 
 # Check for preqrequisites.
 for prereq in "git"; do
-	if ! which "${prereq}" > /dev/null 2>&1; then
+	if ! type -p "${prereq}" > /dev/null 2>&1; then
 		echo "goprecommit: ${prereq} must be installed and in the path." 2>&1
 		exit 1
 	fi
@@ -46,47 +35,12 @@ fatal*|false)
 ;;
 esac
 
-# Ensure $GOPATH/bin is in $PATH
-GOPATH_IN_PATH="false"
-i=0
-while read path; do
-	if [[ "$path" == "${GOPATH}/bin" ]]; then
-		GOPATH_IN_PATH="true"
-		break
-	fi
-done < <( echo $PATH | tr ':' '\n' )
-
-# If $GOPATH/bin is not in $PATH put it at the end.
-[[ "$GOPATH_IN_PATH" == "true" ]] || PATH="${PATH}:${GOPATH}/bin"
-
-if ! which golint > /dev/null 2>&1; then
-	echo "getting golint…"
-
-	"${GO}" get -u golang.org/x/lint/golint
-
-	if !which golint > /dev/null 2>&1; then
-		echo "goprecommit: could not locate golint even after go get" 2>&1
-		exit 1
-	fi
-fi
-
-if ! which goimports > /dev/null 2>&1; then
-	echo "getting goimports…"
-
-	"${GO}" get -u golang.org/x/tools/cmd/goimports
-
-	if !which goimports> /dev/null 2>&1; then
-		echo "goprecommit: could not locate goimports even after go get" 2>&1
-		exit 1
-	fi
-fi
-
 VERBOSE="false"
 SHORT="false"
 QUIET="false"
 
 LINT="true"
-[[ -n $GOPRECOMMIT_NOLINT ]] && LINT="false"
+[[ $GOPRECOMMIT_NOLINT = "true" ]] && LINT="false"
 
 while [[ $# -gt 0 ]]; do
 	key="$1"
@@ -138,9 +92,12 @@ while [[ $# -gt 0 ]]; do
 		QUIET="false"
 	;;
 	--short)
+		VERBOSE="false"
 		SHORT="true"
+		QUIET="false"
 	;;
 	--quiet)
+		VERBOSE="false"
 		SHORT="true"
 		QUIET="true"
 	;;
@@ -149,7 +106,7 @@ while [[ $# -gt 0 ]]; do
 		break
 	;;
 	--*)
-		echo "unknown flag $1" >&2
+		echo "unknown flag $key" >&2
 		exit 1
 	;;
 	*)
@@ -159,237 +116,327 @@ while [[ $# -gt 0 ]]; do
 	shift
 done
 
-VERSION="$( "${GO}" version | awk '//{ print $3 }' )"
+function printf_verbose { true ; }
+if [[ $VERBOSE == "true" ]]; then
+	function printf_verbose { printf "$@" ; }
+fi
+
+function printf_not_short { printf "$@" ; }
+if [[ $SHORT == "true" ]]; then
+	function printf_not_short { true ; }
+fi
+
+
+function printf_not_quiet { printf "$@" ; }
+if [[ $QUIET == "true" ]]; then
+	function printf_not_quiet { true ; }
+fi
+
+function log_hide { printf_not_short "%s: \e[0;30;1m%s\e[m\n" "$1" "$2" ;  }	# BOLD dark gray on black
+function log_ok { printf_not_short "%s: \e[0;92;1m%s\e[m\n" "$1" "$2" ; }	# BOLD green on black
+function log_info { printf_not_short "%s: \e[0;94;1m%s\e[m\n" "$1" "$2" ; }	# BOLD blue on black
+function log_notice { printf_not_short "%s: \e[0;96;1m%s\e[m\n" "$1" "$2" ; }	# BOLD cyan on black
+function log_warning { printf_not_short "%s: \e[0;93;1m%s\e[m\n" "$1" "$2" ; }	# BOLD yellow on black
+function log_error { printf_not_quiet "%s: \e[0;91;1m%s\e[m\n" "$1" "$2" ; }	# BOLD red on black
+
+function gopath_bin_in_path {
+	# Ensure $GOPATH/bin is in $PATH
+	local path
+
+	while read -r path; do
+		if [[ "$path" == "${GOPATH}/bin" ]]; then
+			return 0
+			break
+		fi
+	done < <( echo $PATH | tr ':' '\n' )
+
+	return 1
+}
+
+# If $GOPATH/bin is not in $PATH put it at the end.
+gopath_bin_in_path || PATH="${PATH}:${GOPATH}/bin"
+
+VERSION="$( "$GO" version | awk '//{ print $3 }' )"
 VERSION="${VERSION#go}"
 
-[[ "$VERBOSE" == "true" ]] && printf "found %s\n" "${VERSION}"
+printf_verbose "found go version %s\n" "${VERSION}"
 
-GO_MOD="false"
+function go_install {
+	local bin="$1"
+	local pkg="$2"
 
-case "${VERSION}" in
-1.[0123456789]|1.[0123456789].*|1.[0123456789][a-z]*)
-;;
-1.10|1.10.*|1.10[a-z]*)
-;;
-1.11beta2)
-	GO_MOD="true"
-	GO_MOD_TIDY="-sync"
-;;
-*)
-	GO_MOD="true"
-	GO_MOD_TIDY="tidy"
+	if type -p $bin > /dev/null 2>&1; then
+		return 0
+	fi
+
+	case "${VERSION}" in
+	1.[0123456789]|1.[0123456789].*|1.[0123456789][a-z]*)
+		"$GO" get -u $pkg
+	;;
+	1.1[012345]|1.1[012345].*|1.1[012345][a-z]*)
+		"$GO" get -u $pkg
+	;;
+	*)
+		"$GO" install $pkg@latest
+	;;
+	esac
+
+	if ! type -p $bin > /dev/null 2>&1; then
+		echo "goprecommit: could not locate $bin even after installing $pkg" 2>&1
+		return 1
+	fi
+}
+
+go_install golint golang.org/x/lint/golint
+go_install goimports golang.org/x/tools/cmd/goimports
+
+readarray -t GOMODS < <( git ls-files | grep "\(^\|/\)go\.mod$" | grep -v "\(^\|/\)vendor/" )
+printf_verbose "found go.mods=%d\n" ${#GOMODS[@]}
+
+if [[ ${#GOMODS[@]} -lt 1 ]]; then
+	log_warning "goprecommit" "Could not find any go.mod files."
+	GOMODS+=(".")
+fi
+
+function precommit_module {
+	local gomod="$1"
+	printf_verbose "using go.mod=%s\n" $gomod
+
+	cd "$(dirname $gomod)"
+
+	local GO_MODULES="false"
+
+	case "${VERSION}" in
+	1.[0123456789]|1.[0123456789].*|1.[0123456789][a-z]*)
+	;;
+	1.10|1.10.*|1.10[a-z]*)
+	;;
+	1.11beta2)
+		GO_MODULES="true"
+		GO_MOD_TIDY="-sync"
+	;;
+	*)
+		GO_MODULES="true"
+		GO_MOD_TIDY="tidy"
+	;;
+	esac
+
+	local MOD_PATH="${PWD#$GOPATH/src/}"
+	printf_verbose "found MOD_PATH=%s\n" "$MOD_PATH"
+
+	if [[ $MOD_PATH != $PWD || ! -r go.mod ]]; then
+		printf_verbose "ignoring go modules…\n"
+		unset GO_MODULES
+		unset GO_MOD_TIDY
+	fi
+
+	TESTPKG_PREFIX="./"
+	[[ "$GO_MODULES" == "true" ]] && TESTPKG_PREFIX=""
+
+	if [[ "$GO_MODULES" == "true" && -r "go.mod" ]]; then
+		MOD_BASE="$(awk '/^module/{print $2}' go.mod)"
+		printf_verbose "found MOD_BASE=%s\n" "$MOD_BASE"
+	fi
+
+	printf_verbose "listing go files…\n"
+
+	local file
+	while read -r file; do
+		if ! [[ -s "$file" ]]; then
+			continue
+		fi
+
+		if [[ $( grep -c "^// Code generated .* DO NOT EDIT\.$" "$file" ) -gt 0 ]]; then
+			continue
+		fi
+
+		GOFILES+=("$file")
+	done < <( git ls-files | grep "\.go$" | grep -v "^vendor/" )
+
+	printf_verbose "looking for subrepos…\n"
+
+	local dir
+	local -A SUBREPO
+	while read -r dir; do
+		dir="${dir#./}"
+
+		if [[ -d "${dir}/.git" ]]; then
+			printf_verbose "found subrepo: $dir\n"
+			SUBREPO["$dir"]="true"
+		fi
+
+	done < <( find . -type d -not \( -name ".?*" -prune -o -name "vendor" -prune \) )
+
+	if [[ "$GO_MODULES" == "true" ]]; then
+		printf_verbose "go mod ${GO_MOD_TIDY}…\n"
+		
+		while read -r line; do
+			line="$( echo "$line" | sed 's;^go: ;;' )"
+			log_hide "go mod ${GO_MOD_TIDY}" "$line"
+		done < <( "$GO" mod ${GO_MOD_TIDY} 2>&1 )
+	fi
+
+	printf_verbose "listing packages…\n"
+
+	local pkg
+	while read -r pkg; do
+		pkg="$( echo "$pkg" | sed -e "s;\b\(_$PWD\|$MOD_PATH\)/;;g" -e "s;\b\(_$PWD\|$MOD_PATH\);.;g" )"
+
+		if git check-ignore -q "$pkg"; then
+			# If the project would be ignored in git, then we want to process it.
+			printf_verbose "package is ignored in git: %s\n" "$pkg"
+			continue
+		fi
+
+		if [[ ${SUBREPO["$pkg"]} == "true" ]]; then
+			printf_verbose "package is in a subrepo: %s\n" "$pkg"
+			continue
+		fi
+
+		GOPKGS+=("$pkg")
+		TESTPKGS+=("${TESTPKG_PREFIX}$pkg")
+	done < <( "$GO" list ./... | grep -v "/vendor/" )
+
+	local -i ISSUES
+
+	if [[ ${#GOFILES[@]} -gt 0 ]]; then
+		printf_verbose "gofmt on files…\n"
+
+		while read -r line; do
+			log_error "gofmt" "$line"
+			((ISSUES++))
+		done < <(gofmt -l "${GOFILES[@]}")
+
+		printf_verbose "goimports on files…\n"
+
+		while read -r line; do
+			log_error "goimports" "$line"
+			((ISSUES++))
+		done < <( goimports -l "${GOFILES[@]}" 2>&1 )
+	fi
+
+	if [[ "$LINT" != "false" ]]; then
+		printf_verbose "golint on packages…\n"
+
+		# golint complains if we reference all of the files together, so we need to do a per-package check.
+		# We want to highlight any package that has golint errors, so we do each package separately.
+		for pkg in "${GOPKGS[@]}"; do
+			FLAG="false"
+
+			pkg="${pkg#$MOD_BASE}"
+
+			[[ "$pkg" == "/" ]] && pkg="."
+			pkg="${pkg#/}"
+
+			printf_verbose "$ golint $pkg\n"
+
+			while read -r line; do
+				if [[ "$FLAG" != "true" ]]; then
+					log_error "golint" "$pkg"
+
+					FLAG="true"
+					((ISSUES++))
+				fi
+
+				line=${line#${PWD}/}
+				log_warning "golint" "$line"
+			done < <( golint "$pkg" 2>&1 )
+		done
+	fi
+
+	printf_verbose "go test on packages…\n"
+
+	# Exchange MOD_PATH for MOD_BASE if it is set.
+	[[ -n "$MOD_BASE" ]] && MOD_PATH="$MOD_BASE"
+
+	while IFS='' read -r line; do
+		line="$( echo "$line" | sed -e "s;\b\(_$PWD\|$MOD_PATH\)/;;g" -e "s;\b\(_$PWD\|$MOD_PATH\);.;g" )"
+
+		# Strip leading whitespace for easier matching.
+		case "$( echo "$line" | sed -e 's/^[ \t]*//g' )" in 
+		"go: "*)
+			# go messages should be shadowed.
+			log_hide "go test" "$line"
+		;;
+		ok*\(cached\))
+			# Cached test results should be low-lighted.
+			log_info "go test" "$line"
+		;;
+		ok*)
+			log_ok "go test" "$line"
+		;;
+		PASS*)
+			log_ok "go test" "$line"
+		;;
+		FAIL) ;;
+		---\ FAIL*)
+			# Failures should be highlighted as errors.
+			log_error "go test" "$line"
+			((ISSUES++))
+		;;
+		panic:*\[recovered\])
+			# recovered panics should be shadowed.
+			log_warning "go test" "$line"
+		;;
+		FAIL*|panic:*)
+			# Failures should be highlighted as errors.
+			log_error "go test" "$line"
+			((ISSUES++))
+		;;
+		*cannot\ find\ package*)
+			# Failures should be highlighted as errors.
+			log_error "go test" "$line"
+			((ISSUES++))
+		;;
+		\?*\[no\ test\ files\])
+			pkg="$( echo "$line" | awk '//{ print $2 }' )"
+
+			# If pkg has a leading underscore, then replace "_${PWD}/" with "./".
+			if [[ "${pkg#_}" != "${pkg}" ]]; then
+				pkg=".${pkg#_${PWD}}"
+			fi
+
+			pkgname="$( "$GO" list -f "{{.Name}}" $pkg 2>&1 )"
+			case $pkgname in
+			main)
+				# If a main package does not have tests, then it should be shadowed.
+				log_hide "go test" "$line"
+			;;
+			*)
+				# Non-main packages with no test-files should be lightly highlighted.
+				log_notice "go test" "$line"
+			;;
+			esac
+		;;
+		*)
+			line="$( echo "$line" | sed -e "s;${PWD};.;" )"
+			# Lines that we cannot recognize as anything else should be highlighted as warnings.
+			log_warning "go test" "$line"
+			((ISSUES++)) # should additionally break commit attempt.
+		;;
+		esac
+	done < <( "$GO" test $NOCACHE "${TESTPKGS[@]}" 2>&1 )
+
+	return $ISSUES
+}
+
+BLOCK_COMMIT="false"
+
+for gomod in "${GOMODS[@]}"; do
+	if !( precommit_module $gomod ); then
+		BLOCK_COMMIT="true"
+	fi
+done
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+case $branch in
+master|main)
+	log_error "branch name" "Do not commit to ${branch}."
+	BLOCK_COMMIT="true"
 ;;
 esac
 
-MOD_PATH="${PWD#$GOPATH/src/}"
-[[ "$VERBOSE" == "true" ]] && printf "found MOD_PATH=%s\n" "$MOD_PATH"
+# find * -type f -name "*.*" -exec check-noeol \{\} \+ || BLOCK_COMMIT="true"
 
-if [[ $MOD_PATH != $PWD || ! -r go.mod ]]; then
-	[[ "$VERBOSE" == "true" ]] && printf "ignoring go modules…\n"
-	unset GO_MOD
-	unset GO_MOD_TIDY
-fi
-
-TESTPKG_PREFIX="./"
-[[ "$GO_MOD" == "true" ]] && TESTPKG_PREFIX=""
-
-if [[ "$GO_MOD" == "true" && -r "go.mod" ]]; then
-	MOD_BASE="$(awk '/^module/{print $2}' < go.mod)"
-	[[ "$VERBOSE" == "true" ]] && printf "found MOD_BASE=%s\n" "$MOD_BASE"
-fi
-
-[[ "$VERBOSE" == "true" ]] && printf "listing files…\n"
-
-i=0
-while read file; do
-	if ! [[ -s "$file" ]]; then
-		continue
-	fi
-
-	if [[ $( grep -c "^// Code generated .* DO NOT EDIT\.$" "$file" ) != 0 ]]; then
-		continue
-	fi
-
-	GOFILES[ $i ]="$file"
-	(( i++ ))
-done < <( git ls-files | grep "\.go$" | grep -v "^vendor/" )
-
-[[ "$VERBOSE" == "true" ]] && printf "looking for subrepos…\n"
-
-i=0
-while read dir; do
-	dir="${dir#./}"
-
-	if [[ -d "${dir}/.git" ]]; then
-		[[ "$VERBOSE" == "true" ]] && printf "found subrepo: $dir\n"
-		SUBREPO[ $i ]="$dir"
-		(( i++ ))
-	fi
-
-done < <( find . -type d -not -name ".*" | grep -v -e "/vendor/" -e "/\." )
-
-if [[ "$GO_MOD" == "true" ]]; then
-	[[ "$VERBOSE" == "true" ]] && printf "go mod ${GO_MOD_TIDY}…\n"
-	
-	while read line; do
-		line="$( echo "$line" | sed "s|^go: ||" )"
-		[[ "$SHORT" != "true" ]] && printf "go mod ${GO_MOD_TIDY}: ${HIDE}%s${NORMAL}\n" "$line"
-	done < <( "${GO}" mod ${GO_MOD_TIDY} 2>&1 )
-fi
-
-[[ "$VERBOSE" == "true" ]] && printf "listing packages…\n"
-
-i=0
-while read pkg; do
-	pkg="$( echo "$pkg" | sed "s|\b_$PWD/||" | sed "s|\b_$PWD|.|" )"
-	pkg="${pkg#$MOD_PATH/}"
-
-	[[ "$pkg" == "$MOD_PATH" ]] && pkg="."
-
-	if git check-ignore -q "${pkg}"; then
-		# If the project would be ignored in git, then we want to process it.
-		[[ "$VERBOSE" == "true" ]] && printf "package is ignored in git: %s\n" "${pkg}"
-		continue
-	fi
-
-	IN_SUBREPO="false"
-
-	for subrepo in "${SUBREPO[@]}"; do
-		if [[ "${pkg#$subrepo}" != "${pkg}" ]]; then
-			[[ "$VERBOSE" == "true" ]] && printf "package is in a subrepo: %s\n" "${pkg}"
-			IN_SUBREPO="true"
-			break
-		fi
-	done
-
-	if [[ "$IN_SUBREPO" == "false" ]]; then
-		GOPKGS[ $i ]="$pkg"
-		TESTPKGS[ $i ]="${TESTPKG_PREFIX}$pkg"
-		(( i++ ))
-	fi
-done < <( "${GO}" list ./... | grep -v "/vendor/" )
-
-EXIT="false"
-
-if [[ ${#GOFILES[@]} -gt 0 ]]; then
-	[[ "$VERBOSE" == "true" ]] && printf "gofmt on files…\n"
-
-	while read line; do
-		[[ "$QUIET" != "true" ]] && printf "gofmt: ${ERROR}%s${NORMAL}\n" "$line"
-		EXIT="true"
-	done < <(gofmt -l "${GOFILES[@]}")
-
-	[[ "$VERBOSE" == "true" ]] && printf "goimports on files…\n"
-
-	while read line; do
-		[[ "$QUIET" != "true" ]] && printf "goimports: ${ERROR}%s${NORMAL}\n" "$line"
-		EXIT="true"
-	done < <( goimports -l "${GOFILES[@]}" 2>&1 )
-fi
-
-if [[ "$LINT" != "false" ]]; then
-	[[ "$VERBOSE" == "true" ]] && printf "golint on packages…\n"
-
-	# golint complains if we reference all of the files together, so we need to do a per-package check.
-	# We want to highlight any package that has golint errors, so we do each package separately.
-	for pkg in "${GOPKGS[@]}"; do
-		FLAG="false"
-
-		pkg="${pkg#$MOD_BASE}"
-
-		[[ "$pkg" == "/" ]] && pkg="."
-		pkg="${pkg#/}"
-
-		[[ "$VERBOSE" == "true" ]] && printf "$ golint $pkg\n"
-
-		while read line; do
-			if [[ "$FLAG" != "true" ]]; then
-				[[ "$QUIET" != "true" ]] && printf "golint: ${ERROR}%s${NORMAL}\n" "$pkg"
-
-				FLAG="true"
-				EXIT="true"
-			fi
-
-			line=${line#${PWD}/}
-			[[ "$SHORT" != "true" ]] && printf "golint: ${WARNING}%s${NORMAL}\n" "$line"
-		done < <( golint "$pkg" 2>&1 )
-	done
-fi
-
-[[ "$VERBOSE" == "true" ]] && printf "go test on packages…\n"
-
-# Exchange MOD_PATH for MOD_BASE if it is set.
-[[ -n "$MOD_BASE" ]] && MOD_PATH="$MOD_BASE"
-
-while read line; do
-	line="$( echo "$line" | sed "s|\b_$PWD/||" | sed "s|\b_$PWD|.|" | sed "s|\b$MOD_PATH/||" | sed "s|\b$MOD_PATH|.|")"
-
-	case "$line" in
-	"go: "*)
-		# go messages should be shadowed.
-		[[ "$SHORT" != "true" ]] && printf "go test: ${HIDE}%s${NORMAL}\n" "$line"
-	;;
-	ok*\(cached\))
-		# Cached test results should be low-lighted.
-		[[ "$SHORT" != "true" ]] && printf "go test: ${INFO}%s${NORMAL}\n" "$line"
-	;;
-	ok*)
-		[[ "$QUIET" != "true" ]] && printf "go test: ${GOOD}%s${NORMAL}\n" "$line"
-	;;
-	PASS*)
-		[[ "$QUIET" != "true" ]] && printf "go test: ${GOOD}%s${NORMAL}\n" "$line"
-	;;
-	FAIL) ;;
-	---\ FAIL*)
-		# Failures should be highlighted as errors.
-		[[ "$SHORT" != "true" ]] && printf "go test: ${ERROR}%s${NORMAL}\n" "$line"
-		EXIT="true"
-	;;
-	FAIL*)
-		# Failures should be highlighted as errors.
-		[[ "$QUIET" != "true" ]] && printf "go test: ${ERROR}%s${NORMAL}\n" "$line"
-		EXIT="true"
-	;;
-	*cannot\ find\ package*)
-		# Failures should be highlighted as errors.
-		[[ "$QUIET" != "true" ]] && printf "go test: ${ERROR}%s${NORMAL}\n" "$line"
-		EXIT="true"
-	;;
-	\?*\[no\ test\ files\])
-		pkg="$( echo $line | awk '//{ print $2 }' )"
-
-		# If pkg has a leading underscore, then replace "_${PWD}/" with "./".
-		if [[ "${pkg#_}" != "${pkg}" ]]; then
-			pkg=".${pkg#_${PWD}}"
-		fi
-
-		pkgname="$( "${GO}" list -f "{{.Name}}" $pkg 2>&1 )"
-		case $pkgname in
-		main)
-			# If a main package does not have tests, then it should be shadowed.
-			[[ "$SHORT" != "true" ]] && printf "go test: ${HIDE}%s${NORMAL}\n" "$line"
-		;;
-		*)
-			# Non-main packages with no test-files should be lightly highlighted.
-			[[ "$SHORT" != "true" ]] && printf "go test: ${NOTICE}%s${NORMAL}\n" "$line"
-		;;
-		esac
-	;;
-	*)
-		# Lines that we cannot recognize as anything else should be highlighted as warnings.
-		[[ "$QUIET" != "true" ]] && printf "go test: ${WARNING}%s${NORMAL}\n" "$line"
-		EXIT="true" # should additionally break commit attempt.
-	;;
-	esac
-done < <( "${GO}" test $NOCACHE "${TESTPKGS[@]}" 2>&1 )
-
-branch="$(git rev-parse --abbrev-ref HEAD)"
-if [[ $branch == "master" ]]; then
-	[[ "$QUIET" != "true" ]] && printf "branch name: ${ERROR}Do not commit to master${NORMAL}\n"
-	EXIT="true"
-fi
-
-find * -type f -name "*.*" -exec check-noeol \{\} \+ || EXIT="true"
-
-[[ "$EXIT" == "true" ]] && exit 1
+[[ "$BLOCK_COMMIT" == "true" ]] && exit 1
 exit 0


### PR DESCRIPTION
A few different things:
* use bash functions
* using bash functions support multiple `go.mod` modules in one repo
* don’t rely on `which` as much, `type -p` in bash has the functionality we need
* a bit more robust `read line` work
* don’t strip leading/following newlines from `go test` output, to preserve indentions
* use `find` with `-prune` rather than sending the output through a secondary grep
* from `go1.16` and on, use `go install package@latest` to install `golint` and `goimports`
* use an associative array with `SUBPKGS` for simpler checking if a `$pkg` is in the set
* use `ARRAY+=(value)` notation rather than a temporary counter